### PR TITLE
Feat/fn 91 global auth state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@tanstack/react-query": "^5.85.6",
         "@tanstack/react-query-devtools": "^5.87.4",
         "@tanstack/react-router": "^1.131.32",
-        "@tanstack/react-router-devtools": "^1.131.32",
         "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2114,14 +2113,14 @@
       }
     },
     "node_modules/@tanstack/react-router": {
-      "version": "1.131.32",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.131.32.tgz",
-      "integrity": "sha512-QvT7vV8ic7jOh3U8c2FkzdnHZ7eejPaneNQacJm4Op28aSpkFRwIU3S15pPYqyiLr8DnG5L75ADfSqlJ18ZGpw==",
+      "version": "1.131.41",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.131.41.tgz",
+      "integrity": "sha512-QEbTYpAosiD8e4qEZRr9aJipGSb8pQc+pfZwK6NCD2Tcxwu2oF6MVtwv0bIDLRpZP0VJMBpxXlTRISUDNMNqIA==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.131.2",
         "@tanstack/react-store": "^0.7.0",
-        "@tanstack/router-core": "1.131.32",
+        "@tanstack/router-core": "1.131.41",
         "isbot": "^5.1.22",
         "tiny-invariant": "^1.3.3",
         "tiny-warning": "^1.0.3"
@@ -2138,13 +2137,19 @@
         "react-dom": ">=18.0.0 || >=19.0.0"
       }
     },
-    "node_modules/@tanstack/react-router-devtools": {
-      "version": "1.131.32",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router-devtools/-/react-router-devtools-1.131.32.tgz",
-      "integrity": "sha512-7Pf25kSEJfAUqYlxuQb+Nquy7YUO1rOsrbYeeU1rv0WYSiyB0dOAOZmcRmQ0zl2TCtEkZnepcL5Hbmb5CamMBA==",
+    "node_modules/@tanstack/react-router/node_modules/@tanstack/router-core": {
+      "version": "1.131.41",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.131.41.tgz",
+      "integrity": "sha512-VoLly00DWM0abKuVPRm8wiwGtRBHOKs6K896fy48Q/KYoDVLs8kRCRjFGS7rGnYC2FIkmmvHqYRqNg7jgCx2yg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/router-devtools-core": "1.131.32"
+        "@tanstack/history": "1.131.2",
+        "@tanstack/store": "^0.7.0",
+        "cookie-es": "^1.2.2",
+        "seroval": "^1.3.2",
+        "seroval-plugins": "^1.3.2",
+        "tiny-invariant": "^1.3.3",
+        "tiny-warning": "^1.0.3"
       },
       "engines": {
         "node": ">=12"
@@ -2152,11 +2157,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/react-router": "^1.131.32",
-        "react": ">=18.0.0 || >=19.0.0",
-        "react-dom": ">=18.0.0 || >=19.0.0"
       }
     },
     "node_modules/@tanstack/react-store": {
@@ -2181,6 +2181,7 @@
       "version": "1.131.32",
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.131.32.tgz",
       "integrity": "sha512-6pIX4ZS6tyxVTQKAKsGE6xl6S7OekyPPRqEbOTmIxUJ5vBL0iAu3ir7YTk5a7PEM6lDe/nUI2oVV5zkarEEiPQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.131.2",
@@ -2197,35 +2198,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/router-devtools-core": {
-      "version": "1.131.32",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-devtools-core/-/router-devtools-core-1.131.32.tgz",
-      "integrity": "sha512-VQPAA/B9L68hl16KyIonUEooJOfL75rJJjfashcVGDRsssGCCfCjvHS8Cw0mSYeVJ0iawgKPdIUyCZAqGycYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1",
-        "goober": "^2.1.16",
-        "solid-js": "^1.9.5"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "@tanstack/router-core": "^1.131.32",
-        "csstype": "^3.0.10",
-        "solid-js": ">=1.9.5",
-        "tiny-invariant": "^1.3.3"
-      },
-      "peerDependenciesMeta": {
-        "csstype": {
-          "optional": true
-        }
       }
     },
     "node_modules/@tanstack/router-generator": {
@@ -3159,6 +3131,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3817,15 +3790,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/goober": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
-      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -4964,17 +4928,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/solid-js": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.9.tgz",
-      "integrity": "sha512-A0ZBPJQldAeGCTW0YRYJmt7RCeh5rbFfPZ2aOttgYnctHE7HgKeHCBB/PVc2P7eOfmNXqMFFFoYYdm3S4dcbkA==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.1.0",
-        "seroval": "~1.3.0",
-        "seroval-plugins": "~1.3.0"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@tanstack/react-query": "^5.85.6",
     "@tanstack/react-query-devtools": "^5.87.4",
     "@tanstack/react-router": "^1.131.32",
-    "@tanstack/react-router-devtools": "^1.131.32",
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,19 @@ import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-const router = createRouter({ routeTree });
+import useAuthStore, { type AuthState } from "@/stores/auth";
 declare module "@tanstack/react-router" {
   interface Register {
     router: typeof router;
+    context: () => { auth: AuthState | undefined };
   }
 }
+const router = createRouter({
+  routeTree,
+  context: {
+    auth: undefined!,
+  },
+});
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -21,11 +28,16 @@ function App() {
   return (
     <div className="min-w-dvw min-h-dvh p-8 bg-gray-50">
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
+        <InnerApp />
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </div>
   );
+}
+
+function InnerApp() {
+  const auth = useAuthStore();
+  return <RouterProvider router={router} context={{ auth }} />;
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import { createRouter, RouterProvider } from "@tanstack/react-router";
-import { routeTree } from "./routeTree.gen";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import useAuthStore, { type AuthState } from "@/stores/auth";
+import { routeTree } from "./routeTree.gen";
+import useAuthStore from "@/stores/useAuthStore";
+import { type AuthState } from "@/stores/useAuthStore";
+
 declare module "@tanstack/react-router" {
   interface Register {
     router: typeof router;
@@ -25,19 +27,16 @@ const queryClient = new QueryClient({
 });
 
 function App() {
+  const auth = useAuthStore();
+
   return (
     <div className="min-w-dvw min-h-dvh p-8 bg-gray-50">
       <QueryClientProvider client={queryClient}>
-        <InnerApp />
+        <RouterProvider router={router} context={{ auth }} />
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </div>
   );
-}
-
-function InnerApp() {
-  const auth = useAuthStore();
-  return <RouterProvider router={router} context={{ auth }} />;
 }
 
 export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from '@/App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -12,18 +12,18 @@ import { authApi, type UserLoginRequest } from "@/shared/apis";
 import { useNavigate } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { useMutation } from "@tanstack/react-query";
-import useAuthStore from "@/stores/auth";
+import useAuthStore from "@/stores/useAuthStore";
 
 type FieldState = UserLoginRequest;
 
 const Login = () => {
   const navigate = useNavigate({ from: "/auth/register" });
   const { getValues, register } = useForm<FieldState>({});
-  const { setState } = useAuthStore;
+  const updateAccessToken = useAuthStore((state) => state.updateAccessToken);
   const { mutate: login } = useMutation({
     mutationFn: authApi.login,
     onSuccess: (res) => {
-      setState({ accessToken: res.data.accessToken });
+      updateAccessToken(res.data.data.accessToken);
       navigate({ to: "/" });
     },
   });

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
-import { Outlet, createRootRoute } from "@tanstack/react-router";
+import { Outlet, createRootRouteWithContext } from "@tanstack/react-router";
+import type { AuthState } from "@/stores/auth";
 
-export const Route = createRootRoute({
+interface RouterContext {
+  auth: AuthState;
+}
+export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,
 });
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Outlet, createRootRouteWithContext } from "@tanstack/react-router";
-import type { AuthState } from "@/stores/auth";
+import type { AuthState } from "@/stores/useAuthStore";
 
 interface RouterContext {
   auth: AuthState;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -3,7 +3,7 @@ import { Outlet, createRootRouteWithContext } from "@tanstack/react-router";
 import type { AuthState } from "@/stores/useAuthStore";
 
 interface RouterContext {
-  auth: AuthState;
+  auth: AuthState | undefined;
 }
 export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,

--- a/src/routes/__utils/authGuard.ts
+++ b/src/routes/__utils/authGuard.ts
@@ -1,0 +1,30 @@
+import { type AuthState } from "@/stores/useAuthStore";
+import { redirect } from "@tanstack/react-router";
+
+interface Props {
+  auth: AuthState;
+  mode?: "protected" | "non-protected" | "bypass";
+}
+export const authGuard = ({ auth, mode }: Props) => {
+  const isAuthenticated = auth.accessToken && auth.accessToken.length;
+  switch (mode) {
+    case "bypass":
+      return;
+    case "protected":
+      if (!isAuthenticated) {
+        throw redirect({
+          to: "/auth/login",
+          search: {
+            redirect: location.href,
+          },
+          replace: true,
+        });
+      }
+      return;
+    case "non-protected":
+      if (isAuthenticated) {
+        history.back();
+      }
+      return;
+  }
+};

--- a/src/routes/__utils/authGuard.ts
+++ b/src/routes/__utils/authGuard.ts
@@ -2,20 +2,22 @@ import { type AuthState } from "@/stores/useAuthStore";
 import { redirect } from "@tanstack/react-router";
 
 interface Props {
-  auth: AuthState;
+  auth: AuthState | undefined;
   mode?: "protected" | "non-protected" | "bypass";
 }
 export const authGuard = ({ auth, mode }: Props) => {
-  const isAuthenticated = auth.accessToken && auth.accessToken.length;
+  const isAuthenticated = auth && Boolean(auth.accessToken);
   switch (mode) {
     case "bypass":
       return;
     case "protected":
       if (!isAuthenticated) {
+        const href = typeof window !== "undefined" ? window.location.href : "/";
+
         throw redirect({
           to: "/auth/login",
           search: {
-            redirect: location.href,
+            redirect: href,
           },
           replace: true,
         });
@@ -23,7 +25,7 @@ export const authGuard = ({ auth, mode }: Props) => {
       return;
     case "non-protected":
       if (isAuthenticated) {
-        history.back();
+        throw redirect({ to: "/", replace: true });
       }
       return;
   }

--- a/src/routes/auth.login.tsx
+++ b/src/routes/auth.login.tsx
@@ -1,8 +1,12 @@
 import Login from "@/pages/auth/login";
+import { authGuard } from "@/routes/__utils/authGuard";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/auth/login")({
   component: RouteComponent,
+  beforeLoad: ({ context }) => {
+    authGuard({ auth: context.auth, mode: "non-protected" });
+  },
 });
 
 function RouteComponent() {

--- a/src/routes/auth.register.tsx
+++ b/src/routes/auth.register.tsx
@@ -1,8 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
-import Register from "../pages/auth/register";
+import Register from "@/pages/auth/register";
+import { authGuard } from "@/routes/__utils/authGuard";
 
 export const Route = createFileRoute("/auth/register")({
   component: RouteComponent,
+  beforeLoad: ({ context }) => {
+    authGuard({ auth: context.auth, mode: "non-protected" });
+  },
 });
 
 function RouteComponent() {

--- a/src/routes/can-access-anyone.tsx
+++ b/src/routes/can-access-anyone.tsx
@@ -1,7 +1,11 @@
+import { authGuard } from "@/routes/__utils/authGuard";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/can-access-anyone")({
   component: RouteComponent,
+  beforeLoad: ({ context }) => {
+    authGuard({ auth: context.auth, mode: "bypass" });
+  },
 });
 
 function RouteComponent() {

--- a/src/routes/can-access-only-user.tsx
+++ b/src/routes/can-access-only-user.tsx
@@ -1,7 +1,11 @@
+import { authGuard } from "@/routes/__utils/authGuard";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/can-access-only-user")({
   component: RouteComponent,
+  beforeLoad: ({ context }) => {
+    authGuard({ auth: context.auth, mode: "protected" });
+  },
 });
 
 function RouteComponent() {

--- a/src/routes/cannot-access-user.tsx
+++ b/src/routes/cannot-access-user.tsx
@@ -1,7 +1,11 @@
+import { authGuard } from "@/routes/__utils/authGuard";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/cannot-access-user")({
   component: RouteComponent,
+  beforeLoad: ({ context }) => {
+    authGuard({ auth: context.auth, mode: "non-protected" });
+  },
 });
 
 function RouteComponent() {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,6 +10,9 @@ function RouteComponent() {
       <Link to="/auth/login">로그인 페이지</Link>
       <Link to="/auth/register">회원가입 페이지</Link>
       <Link to="/reset-password">비밀번호 재설정 페이지</Link>
+      <Link to="/can-access-anyone">언제든 접근가능 </Link>
+      <Link to="/can-access-only-user">인증된 유저만 접근가능</Link>
+      <Link to="/cannot-access-user">로그인 안한 사람만 접근가능</Link>
     </div>
   );
 }

--- a/src/shared/apis/auth.ts
+++ b/src/shared/apis/auth.ts
@@ -61,7 +61,7 @@ export interface SocialLinksResponse {
 export const authApi = {
   // 로그인
   login: (data: UserLoginRequest) =>
-    apiClient.post<UserLoginResponse>("/auth/login", data),
+    apiClient.post<{ data: UserLoginResponse }>("/auth/login", data),
 
   // 회원가입
   register: (data: UserRegisterRequest) =>

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+export interface AuthState {
+  accessToken: string | null;
+}
+
+export interface AuthAction {
+  hasAccessToken: () => boolean;
+  removeAccessToken: () => void;
+  updateAccessToken: (accessToken: string) => void;
+}
+
+const useAuthStore = create<AuthState & AuthAction>()(
+  devtools((set, get) => ({
+    accessToken: null,
+    hasAccessToken: () => !!get().accessToken,
+    removeAccessToken: () => set({ accessToken: null }),
+    updateAccessToken: (accessToken) => set({ accessToken }),
+  }))
+);
+
+export default useAuthStore;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 라우터 컨텍스트에 인증 상태 추가로 라우트 단위 접근 제어 지원
  - 페이지 사전 가드 추가: 보호(로그인 필요), 비보호(비로그인 전용), 무시 모드
  - 홈에 신규 링크 3종 추가: 언제든 접근가능, 인증된 유저만 접근가능, 로그인 안한 사람만 접근가능
- 개선
  - 로그인 응답 처리 및 전역 스토어 기반 토큰 관리로 처리 방식 일관성 향상
- 작업
  - 라우터 개발자 도구 의존성 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->