### PR TITLE
Feat/fn 184 commit msg with issue number automation

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,1 @@
+sh ./scripts/prepare-commit-jira.sh $1 $2

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "husky": "^9.1.7",
         "tw-animate-css": "^1.3.7",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.1",
@@ -4245,6 +4246,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "husky": "^9.1.7",
     "tw-animate-css": "^1.3.7",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",

--- a/scripts/prepare-commit-jira.sh
+++ b/scripts/prepare-commit-jira.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Merge commit이나 commit --amend는 스킵
+if [ "$2" = "merge" ] || [ "$2" = "commit" ]; then
+    exit
+fi
+
+# 브랜치에서 Jira 이슈 키 추출
+ISSUE_KEY=$(git branch | grep -o "\* \(.*\/\)*[A-Z]\{2,\}-[0-9]\+" | grep -o "[A-Z]\{2,\}-[0-9]\+")
+if [ $? -ne 0 ]; then
+    exit
+fi
+
+# fixup commit이면 스킵
+FIXUP_COMMIT=$(grep -o "fixup\!" "$1")
+if [ $? -eq 0 ]; then
+    exit
+fi
+
+# 커밋 메시지 첫 줄 읽기
+FIRST_LINE=$(head -n1 "$1")
+
+# feat: 와 같은 타입이 있는지 체크
+if echo "$FIRST_LINE" | grep -qE '^(feat|fix|chore|docs|refactor|test|style|perf|build|ci|revert):'; then
+    # 타입 뒤에 Jira 키 추가
+    NEW_LINE=$(echo "$FIRST_LINE" | sed -E "s/^([a-z]+:)(.*)/\1 [$ISSUE_KEY]\2/")
+    # 커밋 메시지 업데이트
+    sed -i -e "1s/.*/$NEW_LINE/" "$1"
+else
+    # 타입이 없으면 그냥 맨 앞에 Jira 키 붙이기
+    sed -i -e "1s/^/[$ISSUE_KEY] /" "$1"
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Git 훅을 도입해 커밋 메시지 자동화를 추가했습니다.
  - 현재 브랜치에서 Jira 이슈 키를 추출해 커밋 메시지에 자동 삽입합니다. 머지/수정(amend) 커밋과 fixup 커밋은 제외됩니다.
  - 커밋 타입이 있을 경우(type: 형식) 타입 뒤에 키를 삽입하고, 없으면 메시지 앞에 키를 추가합니다.
  - 개발 도구 의존성을 업데이트하여 훅 실행을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->