### PR TITLE
Feat/fn 181 cardset editor UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.8",
@@ -1296,6 +1297,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -1339,6 +1346,32 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-previous": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1417,6 +1450,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1616,6 +1664,49 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/src/features/group/components/GroupFilterSection.tsx
+++ b/src/features/group/components/GroupFilterSection.tsx
@@ -1,0 +1,39 @@
+import { GROUP_CATEGORY_MAP } from "@/domain/group";
+import { Checkbox } from "@/shared/components/checkbox";
+import { Label } from "@/shared/components/label";
+import type { GroupCategory } from "@/shared/apis/types";
+
+interface GroupFilterSectionProps {
+  selectedCategories: GroupCategory[];
+  onCategoryChange: (category: string, checked: boolean) => void;
+}
+
+export const GroupFilterSection = ({
+  selectedCategories,
+  onCategoryChange,
+}: GroupFilterSectionProps) => {
+  return (
+    <div className="bg-gray-50 rounded-lg p-4 mt-2">
+      <h3 className="text-sm font-medium text-gray-700 mb-3">카테고리</h3>
+      <div className="flex flex-wrap gap-4">
+        {Object.entries(GROUP_CATEGORY_MAP).map(([key, displayValue]) => (
+          <div key={key} className="flex items-center space-x-2">
+            <Checkbox
+              id={key}
+              checked={selectedCategories.includes(key as GroupCategory)}
+              onCheckedChange={(checked) =>
+                onCategoryChange(displayValue, !!checked)
+              }
+            />
+            <Label
+              htmlFor={key}
+              className="text-sm font-normal cursor-pointer"
+            >
+              {displayValue}
+            </Label>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/features/group/hooks/useGroups.ts
+++ b/src/features/group/hooks/useGroups.ts
@@ -1,0 +1,70 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { groupApi } from "@/shared/apis/group";
+import type { GroupCategory } from "@/shared/apis/types";
+
+const GROUPS_QUERY_KEY = ["groups"];
+
+interface UseGroupsParams {
+  keyword?: string;
+  category?: GroupCategory;
+  size?: number;
+  sortBy?: string;
+  order?: string;
+}
+
+export const useGroups = (params?: UseGroupsParams) => {
+  return useInfiniteQuery({
+    queryKey: [...GROUPS_QUERY_KEY, params],
+    queryFn: async ({ pageParam }) => {
+      const response = await groupApi.getGroups({
+        ...params,
+        cursor: pageParam,
+        size: params?.size || 20,
+      });
+      return response.data;
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => {
+      return lastPage.data.hasNext ? lastPage.data.nextCursor : undefined;
+    },
+    select: (data) => ({
+      pages: data.pages,
+      pageParams: data.pageParams,
+      groups: data.pages.flatMap((page) => page.data.content),
+    }),
+  });
+};
+
+export const useMyGroups = (params?: UseGroupsParams) => {
+  return useInfiniteQuery({
+    queryKey: [...GROUPS_QUERY_KEY, "my", params],
+    queryFn: async ({ pageParam }) => {
+      const response = await groupApi.getMyGroups({
+        ...params,
+        cursor: pageParam,
+        size: params?.size || 20,
+      });
+      return response.data;
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => {
+      return lastPage.data.hasNext ? lastPage.data.nextCursor : undefined;
+    },
+    select: (data) => ({
+      pages: data.pages,
+      pageParams: data.pageParams,
+      groups: data.pages.flatMap((page) => page.data.content),
+    }),
+  });
+};
+
+export const useGroup = (groupId: number) => {
+  return useQuery({
+    queryKey: [...GROUPS_QUERY_KEY, groupId],
+    queryFn: async () => {
+      const response = await groupApi.getGroupDetail(groupId);
+      return response.data.data;
+    },
+    enabled: !!groupId,
+  });
+};

--- a/src/pages/group-list.tsx
+++ b/src/pages/group-list.tsx
@@ -1,38 +1,73 @@
 import { GROUP_CATEGORY, type GroupBrief } from "@/domain/group";
+import { Button } from "@/shared/components/button";
 import { Card, CardContent, CardDescription } from "@/shared/components/card";
 import { Checkbox } from "@/shared/components/checkbox";
 import { Input } from "@/shared/components/input";
 import { Label } from "@/shared/components/label";
 import BaseLayout from "@/shared/layouts/base-layout";
 import { Link } from "@tanstack/react-router";
+import { Plus, Search } from "lucide-react";
 
 const GroupList = () => {
-  /** 내가 참여한 그룹인지도  */
-
   return (
     <BaseLayout>
-      <div className="grid grid-cols-4 gap-4 ">
-        {/* 검색 영역 */}
+      {/* 검색 영역 */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+        <Input
+          placeholder="스터디 그룹을 검색해보세요"
+          className="pl-10 bg-white"
+        />
+      </div>
 
-        <Input value="검색해보세요" placeholder="검색해보세요" />
-        <div>
+      {/* 필터 영역 */}
+      <div className="bg-gray-50 rounded-lg p-4 mt-2">
+        <h3 className="text-sm font-medium text-gray-700 mb-3">카테고리</h3>
+        <div className="flex flex-wrap gap-4">
           {GROUP_CATEGORY.map((category) => (
-            <>
-              <Label>{category}</Label>
-              <Checkbox />
-            </>
+            <div key={category} className="flex items-center space-x-2">
+              <Checkbox id={category} />
+              <Label
+                htmlFor={category}
+                className="text-sm font-normal cursor-pointer"
+              >
+                {category}
+              </Label>
+            </div>
           ))}
         </div>
-        {/* 리스트 영역 */}
+      </div>
+
+      {/* 생성 버튼 */}
+      <div className="flex justify-end mt-2">
+        <Button className="flex items-center gap-2">
+          <Plus className="w-4 h-4" />
+          그룹 생성
+        </Button>
+      </div>
+
+      {/* 그룹 리스트 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-4">
         {mockData.map((group) => (
           <Link to="/" key={group.id}>
-            <Card className="p-0 overflow-hidden">
-              <div className="w-full h-28">
-                <img src={group.image} alt={`${group.name}의 썸네일`} />
+            <Card className="overflow-hidden hover:shadow-lg transition-shadow duration-200 cursor-pointer">
+              <div className="w-full h-40 bg-gray-100">
+                <img
+                  src={group.image}
+                  alt={`${group.name}의 썸네일`}
+                  className="w-full h-full object-cover"
+                />
               </div>
               <CardContent className="p-4">
-                {group.name}
-                <CardDescription>{group.description}</CardDescription>
+                <h3 className="font-semibold text-gray-900 mb-2 line-clamp-1">
+                  {group.name}
+                </h3>
+                <CardDescription className="line-clamp-2 text-sm">
+                  {group.description}
+                </CardDescription>
+                <div className="mt-3 text-xs text-gray-500">
+                  {group.createdAt.toLocaleDateString()}
+                </div>
               </CardContent>
             </Card>
           </Link>

--- a/src/pages/group-list.tsx
+++ b/src/pages/group-list.tsx
@@ -1,135 +1,218 @@
-import { GROUP_CATEGORY, type GroupBrief } from "@/domain/group";
 import { Button } from "@/shared/components/button";
 import { Card, CardContent, CardDescription } from "@/shared/components/card";
-import { Checkbox } from "@/shared/components/checkbox";
 import { Input } from "@/shared/components/input";
-import { Label } from "@/shared/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/components/select";
 import BaseLayout from "@/shared/layouts/base-layout";
 import { Link } from "@tanstack/react-router";
 import { Plus, Search } from "lucide-react";
+import { useGroups } from "@/features/group/hooks/useGroups";
+import { GroupFilterSection } from "@/features/group/components/GroupFilterSection";
+import { GROUP_CATEGORY_MAP } from "@/domain/group";
+import { useState, useEffect } from "react";
+import type { GroupCategory } from "@/shared/apis/types";
 
 const GroupList = () => {
+  const [searchInput, setSearchInput] = useState("");
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<
+    GroupCategory | undefined
+  >(undefined);
+  const [sortBy, setSortBy] = useState("createdAt");
+  const [order, setOrder] = useState<"ASC" | "DESC">("DESC");
+
+  // Debounce 검색어 처리
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchKeyword(searchInput);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  // API에서 그룹 데이터 가져오기
+  const {
+    data: groupsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    error,
+  } = useGroups({
+    keyword: searchKeyword || undefined,
+    category: selectedCategory,
+    size: 20,
+    sortBy,
+    order,
+  });
+
+  // 카테고리 체크박스 핸들러
+  const handleCategoryChange = (displayValue: string, checked: boolean) => {
+    // GROUP_CATEGORY_MAP에서 표시 값에 해당하는 키를 찾음
+    const categoryKey = Object.keys(GROUP_CATEGORY_MAP).find(
+      key => GROUP_CATEGORY_MAP[key as keyof typeof GROUP_CATEGORY_MAP] === displayValue
+    ) as GroupCategory;
+
+    setSelectedCategory(checked ? categoryKey : undefined);
+  };
+
+  // 정렬 필드 핸들러
+  const handleSortByChange = (value: string) => {
+    setSortBy(value);
+  };
+
+  // 정렬 순서 핸들러
+  const handleOrderChange = (value: string) => {
+    setOrder(value as "ASC" | "DESC");
+  };
+
+  if (isLoading) {
+    return (
+      <BaseLayout>
+        <div className="flex justify-center items-center min-h-[400px]">
+          <div className="text-gray-500">로딩 중...</div>
+        </div>
+      </BaseLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <BaseLayout>
+        <div className="flex justify-center items-center min-h-[400px]">
+          <div className="text-red-500">데이터를 불러오는데 실패했습니다.</div>
+        </div>
+      </BaseLayout>
+    );
+  }
+
   return (
     <BaseLayout>
-      {/* 검색 영역 */}
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
-        <Input
-          placeholder="스터디 그룹을 검색해보세요"
-          className="pl-10 bg-white"
-        />
-      </div>
+      <div className="space-y-6">
+        {/* 검색 및 헤더 영역 */}
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-bold text-gray-900">그룹 목록</h1>
+            <Button className="flex items-center gap-2">
+              <Plus className="w-4 h-4" />
+              그룹 생성
+            </Button>
+          </div>
 
-      {/* 필터 영역 */}
-      <div className="bg-gray-50 rounded-lg p-4 mt-2">
-        <h3 className="text-sm font-medium text-gray-700 mb-3">카테고리</h3>
-        <div className="flex flex-wrap gap-4">
-          {GROUP_CATEGORY.map((category) => (
-            <div key={category} className="flex items-center space-x-2">
-              <Checkbox id={category} />
-              <Label
-                htmlFor={category}
-                className="text-sm font-normal cursor-pointer"
-              >
-                {category}
-              </Label>
-            </div>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+            <Input
+              placeholder="스터디 그룹을 검색해보세요"
+              className="pl-10"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+            />
+          </div>
+        </div>
+
+        {/* 필터 및 정렬 영역 */}
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex-1">
+            <GroupFilterSection
+              selectedCategories={selectedCategory ? [selectedCategory] : []}
+              onCategoryChange={handleCategoryChange}
+            />
+          </div>
+
+          <div className="flex items-center gap-2 text-sm text-gray-600">
+            <span>정렬:</span>
+            <Select value={sortBy} onValueChange={handleSortByChange}>
+              <SelectTrigger className="w-24 h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="createdAt">생성일</SelectItem>
+                <SelectItem value="name">이름</SelectItem>
+                <SelectItem value="modifiedAt">수정일</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={order} onValueChange={handleOrderChange}>
+              <SelectTrigger className="w-20 h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="DESC">내림차순↓</SelectItem>
+                <SelectItem value="ASC">오름차순↑</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* 그룹 리스트 */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          {groupsData?.groups.map((group) => (
+            <Link
+              to="/groups/$id"
+              params={{ id: group.groupId.toString() }}
+              key={group.groupId}
+            >
+              <Card className="overflow-hidden hover:shadow-lg transition-shadow duration-200 cursor-pointer">
+                <div className="w-full h-40 bg-gray-100">
+                  {group.imageUrl ? (
+                    <img
+                      src={group.imageUrl}
+                      alt={`${group.name}의 썸네일`}
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-gray-400">
+                      No Image
+                    </div>
+                  )}
+                </div>
+                <CardContent className="p-4">
+                  <h3 className="font-semibold text-gray-900 mb-2 line-clamp-1">
+                    {group.name}
+                  </h3>
+                  <CardDescription className="line-clamp-2 text-sm">
+                    {group.description}
+                  </CardDescription>
+                  <div className="mt-3 flex justify-between items-center">
+                    <span className="text-xs text-gray-500">
+                      {group.category}
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
           ))}
         </div>
-      </div>
 
-      {/* 생성 버튼 */}
-      <div className="flex justify-end mt-2">
-        <Button className="flex items-center gap-2">
-          <Plus className="w-4 h-4" />
-          그룹 생성
-        </Button>
-      </div>
+        {/* 더 보기 버튼 */}
+        {hasNextPage && (
+          <div className="flex justify-center">
+            <Button
+              onClick={() => fetchNextPage()}
+              disabled={isFetchingNextPage}
+              variant="outline"
+            >
+              {isFetchingNextPage ? "로딩 중..." : "더 보기"}
+            </Button>
+          </div>
+        )}
 
-      {/* 그룹 리스트 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 mt-4">
-        {mockData.map((group) => (
-          <Link to="/" key={group.id}>
-            <Card className="overflow-hidden hover:shadow-lg transition-shadow duration-200 cursor-pointer">
-              <div className="w-full h-40 bg-gray-100">
-                <img
-                  src={group.image}
-                  alt={`${group.name}의 썸네일`}
-                  className="w-full h-full object-cover"
-                />
+        {/* 결과 없음 */}
+        {(!groupsData?.groups || groupsData.groups.length === 0) &&
+          !isLoading && (
+            <div className="flex justify-center items-center min-h-[200px]">
+              <div className="text-gray-500">
+                검색 조건에 맞는 그룹이 없습니다.
               </div>
-              <CardContent className="p-4">
-                <h3 className="font-semibold text-gray-900 mb-2 line-clamp-1">
-                  {group.name}
-                </h3>
-                <CardDescription className="line-clamp-2 text-sm">
-                  {group.description}
-                </CardDescription>
-                <div className="mt-3 text-xs text-gray-500">
-                  {group.createdAt.toLocaleDateString()}
-                </div>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
+            </div>
+          )}
       </div>
     </BaseLayout>
   );
 };
-
-const mockData: GroupBrief[] = [
-  {
-    id: 1,
-    name: "프론트엔드 스터디",
-    description:
-      "React, TypeScript, Next.js를 함께 공부하는 스터디 그룹입니다.",
-    image: "https://picsum.photos/300/200?random=1",
-    createdAt: new Date("2024-01-15"),
-    modifiedAt: new Date("2024-01-20"),
-  },
-  {
-    id: 2,
-    name: "백엔드 개발자 모임",
-    description:
-      "Spring Boot, Node.js, 데이터베이스 설계를 논의하는 모임입니다.",
-    image: "https://picsum.photos/300/200?random=2",
-    createdAt: new Date("2024-01-10"),
-    modifiedAt: new Date("2024-01-18"),
-  },
-  {
-    id: 3,
-    name: "UI/UX 디자인 연구회",
-    description: "사용자 경험과 인터페이스 디자인을 연구하는 그룹입니다.",
-    image: "https://picsum.photos/300/200?random=3",
-    createdAt: new Date("2024-01-05"),
-    modifiedAt: new Date("2024-01-15"),
-  },
-  {
-    id: 4,
-    name: "알고리즘 코딩 테스트",
-    description:
-      "매주 알고리즘 문제를 풀고 코딩 테스트를 준비하는 스터디입니다.",
-    image: "https://picsum.photos/300/200?random=4",
-    createdAt: new Date("2024-01-12"),
-    modifiedAt: new Date("2024-01-22"),
-  },
-  {
-    id: 5,
-    name: "데브옵스 실무 그룹",
-    description:
-      "CI/CD, Docker, Kubernetes 등 데브옵스 기술을 다루는 그룹입니다.",
-    image: "https://picsum.photos/300/200?random=5",
-    createdAt: new Date("2024-01-08"),
-    modifiedAt: new Date("2024-01-19"),
-  },
-  {
-    id: 6,
-    name: "모바일 앱 개발",
-    description: "React Native, Flutter를 이용한 모바일 앱 개발 스터디입니다.",
-    image: "https://picsum.photos/300/200?random=6",
-    createdAt: new Date("2024-01-03"),
-    modifiedAt: new Date("2024-01-17"),
-  },
-];
 
 export default GroupList;

--- a/src/shared/apis/group.ts
+++ b/src/shared/apis/group.ts
@@ -61,6 +61,7 @@ export interface FindGroupMemberResponse {
 }
 
 interface GroupListParams {
+  keyword?: string /** 없는 값임 ㅎ */;
   category?: string;
   cursor?: string;
   size?: number;
@@ -71,11 +72,15 @@ interface GroupListParams {
 export const groupApi = {
   // 그룹 전체 조회 (커서 페이징)
   getGroups: (params?: GroupListParams) =>
-    apiClient.get<ApiResponse<CursorPagingResponse<GroupInfo>>>("/groups", { params }),
+    apiClient.get<ApiResponse<CursorPagingResponse<GroupInfo>>>("/groups", {
+      params,
+    }),
 
   // 내 그룹 전체 조회 (커서 페이징)
   getMyGroups: (params?: GroupListParams) =>
-    apiClient.get<ApiResponse<CursorPagingResponse<GroupInfo>>>("/groups/me", { params }),
+    apiClient.get<ApiResponse<CursorPagingResponse<GroupInfo>>>("/groups/me", {
+      params,
+    }),
 
   // 그룹 상세 조회
   getGroupDetail: (groupId: number) =>
@@ -94,5 +99,7 @@ export const groupApi = {
 
   // 그룹 멤버 조회
   getGroupMembers: (groupId: number) =>
-    apiClient.get<ApiResponse<FindGroupMemberResponse>>(`/groups/${groupId}/members`),
+    apiClient.get<ApiResponse<FindGroupMemberResponse>>(
+      `/groups/${groupId}/members`
+    ),
 };

--- a/src/shared/components/select.tsx
+++ b/src/shared/components/select.tsx
@@ -1,0 +1,183 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+import { cn } from "@/shared/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 그룹 목록: 디바운스 검색, 카테고리 필터, 정렬/정렬순 선택, “더 보기” 페이지네이션, 빈 결과 안내, “그룹 생성” 버튼 추가
  - 그룹 카드 UI 개선(이미지/플레이스홀더, 이름·설명·카테고리 표시)
  - 공용 Select 컴포넌트 도입으로 일관된 선택 UI 제공
- 작업
  - Radix UI Select 의존성 추가 (@radix-ui/react-select)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->