### PR TITLE
Fn 129 create cardset

### DIFF
--- a/scripts/prepare-commit-jira.sh
+++ b/scripts/prepare-commit-jira.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Merge commit, commit --amend, rebase, cherry-pick 등은 스킵
-if [ "$2" = "merge" ] || [ "$2" = "commit" ] || [ "$2" = "squash" ] || [ "$2" = "message" ]; then
+if [ "$2" = "merge" ] || [ "$2" = "commit" ] || [ "$2" = "squash" ]; then
     exit
 fi
 
@@ -30,8 +30,8 @@ if echo "$FIRST_LINE" | grep -qE '^(feat|fix|chore|docs|refactor|test|style|perf
     # 타입 뒤에 Jira 키 추가
     NEW_LINE=$(echo "$FIRST_LINE" | sed -E "s/^([a-z]+:)(.*)/\1 [$ISSUE_KEY]\2/")
     # 커밋 메시지 업데이트
-    sed -i -e "1s/.*/$NEW_LINE/" "$1"
+    sed -i '' "1s/.*/$NEW_LINE/" "$1"
 else
     # 타입이 없으면 그냥 맨 앞에 Jira 키 붙이기
-    sed -i -e "1s/^/[$ISSUE_KEY] /" "$1"
+    sed -i '' "1s/^/[$ISSUE_KEY] /" "$1"
 fi

--- a/src/features/cardset/components/CardsetCreateDialog.tsx
+++ b/src/features/cardset/components/CardsetCreateDialog.tsx
@@ -1,0 +1,65 @@
+import CardsetCreateForm, {
+  type CardsetCreateFormField,
+} from "@/features/cardset/components/CardsetCreateForm";
+import { cardSetApi, type CreateCardSetRequest } from "@/shared/apis";
+import { Button } from "@/shared/components/button";
+import { Dialog, DialogHeader } from "@/shared/components/dialog";
+import {
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@radix-ui/react-dialog";
+import { useMutation } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+type Props = {
+  groupId: number;
+  renderTrigger: ReactNode;
+};
+
+const CardsetCreateDialog = ({ groupId, renderTrigger }: Props) => {
+  const { mutate } = useMutation({
+    mutationFn: ({
+      groupId,
+      data,
+    }: {
+      groupId: number;
+      data: CreateCardSetRequest;
+    }) => cardSetApi.createCardSet(groupId, data),
+  });
+
+  const handleSubmit = (form: CardsetCreateFormField) => {
+    const data: CreateCardSetRequest = {
+      name: form.name,
+      publicVisible: form.publicVisible ?? true,
+      hashtag: form.hashtag,
+      category: form.category,
+    };
+
+    mutate({ groupId, data });
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger>{renderTrigger}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>카드셋 생성</DialogTitle>
+          {/* <DialogDescription>
+            This action cannot be undone. This will permanently delete your
+            account and remove your data from our servers.
+          </DialogDescription> */}
+        </DialogHeader>
+        <CardsetCreateForm formId="cardset-create" onSubmit={handleSubmit} />
+        <Button form="cardset-create" type="reset">
+          초기화
+        </Button>
+        <Button form="cardset-create" type="submit">
+          생성
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CardsetCreateDialog;

--- a/src/features/cardset/components/CardsetCreateDialog.tsx
+++ b/src/features/cardset/components/CardsetCreateDialog.tsx
@@ -3,14 +3,17 @@ import CardsetCreateForm, {
 } from "@/features/cardset/components/CardsetCreateForm";
 import { cardSetApi, type CreateCardSetRequest } from "@/shared/apis";
 import { Button } from "@/shared/components/button";
-import { Dialog, DialogHeader } from "@/shared/components/dialog";
 import {
+  Dialog,
   DialogContent,
+  DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "@radix-ui/react-dialog";
+} from "@/shared/components/dialog";
 import { useMutation } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+
+const FORM_ID = "cardset-create-form";
 
 type Props = {
   groupId: number;
@@ -32,8 +35,9 @@ const CardsetCreateDialog = ({ groupId, renderTrigger }: Props) => {
     const data: CreateCardSetRequest = {
       name: form.name,
       publicVisible: form.publicVisible ?? true,
-      hashtag: form.hashtag,
+      hashtag: form.hashtag?.map((tag) => tag.name) || [],
       category: form.category,
+      imageRefId: form.imageRefId ? String(form.imageRefId) : "",
     };
 
     mutate({ groupId, data });
@@ -42,19 +46,15 @@ const CardsetCreateDialog = ({ groupId, renderTrigger }: Props) => {
   return (
     <Dialog>
       <DialogTrigger>{renderTrigger}</DialogTrigger>
-      <DialogContent>
+      <DialogContent onInteractOutside={(e) => e.preventDefault()}>
         <DialogHeader>
           <DialogTitle>카드셋 생성</DialogTitle>
-          {/* <DialogDescription>
-            This action cannot be undone. This will permanently delete your
-            account and remove your data from our servers.
-          </DialogDescription> */}
         </DialogHeader>
-        <CardsetCreateForm formId="cardset-create" onSubmit={handleSubmit} />
-        <Button form="cardset-create" type="reset">
+        <CardsetCreateForm formId={FORM_ID} onSubmit={handleSubmit} />
+        <Button form={FORM_ID} type="reset">
           초기화
         </Button>
-        <Button form="cardset-create" type="submit">
+        <Button form={FORM_ID} type="submit">
           생성
         </Button>
       </DialogContent>

--- a/src/features/cardset/components/CardsetCreateDialog.tsx
+++ b/src/features/cardset/components/CardsetCreateDialog.tsx
@@ -37,7 +37,7 @@ const CardsetCreateDialog = ({ groupId, renderTrigger }: Props) => {
       publicVisible: form.publicVisible ?? true,
       hashtag: form.hashtag?.map((tag) => tag.name) || [],
       category: form.category,
-      imageRefId: form.imageRefId ? String(form.imageRefId) : "",
+      imageRefId: form.imageRefId ? form.imageRefId : undefined,
     };
 
     mutate({ groupId, data });

--- a/src/features/cardset/components/CardsetCreateForm.tsx
+++ b/src/features/cardset/components/CardsetCreateForm.tsx
@@ -5,11 +5,15 @@ import {
 } from "@/shared/components/button-checkbox";
 import { Button } from "@/shared/components/button";
 import { Checkbox } from "@/shared/components/checkbox";
-import { ErrorMessage, RequiredLabel } from "@/shared/components/form";
+import {
+  Description,
+  ErrorMessage,
+  RequiredLabel,
+} from "@/shared/components/form";
 import { Input } from "@/shared/components/input";
 import { Label } from "@/shared/components/label";
 import { uploadImage } from "@/shared/lib/upload-image";
-import { Description } from "@radix-ui/react-dialog";
+
 import { X } from "lucide-react";
 import type { ChangeEvent } from "react";
 import { useController, useFieldArray, useForm } from "react-hook-form";
@@ -55,6 +59,20 @@ const CardsetCreateForm = ({ onSubmit, formId = "cardset-form" }: Props) => {
     control,
   });
 
+  const handleChangeImage = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) return;
+    try {
+      const imageRefId = await uploadImage({ file, type: "GROUP" });
+      if (imageRefId) setValue("imageRefId", imageRefId);
+    } catch (e) {
+      console.error(e);
+      /** @todo 커스텀 에러 다이얼로그로 변경 */
+      window.alert("이미지 업로드를 실패했습니다. 재시도해주세요.");
+    }
+  };
+
   return (
     <form id={formId} className="space-y-4" onSubmit={handleSubmit(onSubmit)}>
       <div>
@@ -99,18 +117,7 @@ const CardsetCreateForm = ({ onSubmit, formId = "cardset-form" }: Props) => {
         <Label htmlFor="image" className="mb-2">
           이미지
         </Label>
-        <Input
-          id="image"
-          type="file"
-          onChange={async (e: ChangeEvent<HTMLInputElement>) => {
-            const file = e.target.files?.[0];
-
-            if (!file) return;
-
-            const imageRefId = await uploadImage({ file, type: "GROUP" });
-            if (imageRefId) setValue("imageRefId", imageRefId);
-          }}
-        />
+        <Input id="image" type="file" onChange={handleChangeImage} />
       </div>
 
       <div>

--- a/src/features/cardset/components/CardsetCreateForm.tsx
+++ b/src/features/cardset/components/CardsetCreateForm.tsx
@@ -1,0 +1,107 @@
+import { GROUP_CATEGORY_MAP, type GroupCategory } from "@/domain/group/types";
+import {
+  ButtonCheckbox,
+  ButtonCheckboxGroupField,
+} from "@/shared/components/button-checkbox";
+import { Checkbox } from "@/shared/components/checkbox";
+import { ErrorMessage, RequiredLabel } from "@/shared/components/form";
+import { Input } from "@/shared/components/input";
+import { Label } from "@/shared/components/label";
+import { uploadImage } from "@/shared/lib/upload-image";
+import { Description } from "@radix-ui/react-dialog";
+import type { ChangeEvent } from "react";
+import { useController, useForm } from "react-hook-form";
+
+type FormField = {
+  name: string;
+  publicVisible?: boolean;
+  category: GroupCategory;
+  hashtag: string[];
+  imageRefId: number;
+};
+
+type Props = {
+  onSubmit: (form: FormField) => void;
+  formId?: string;
+};
+
+const CardsetCreateForm = ({ onSubmit, formId = "cardset-form" }: Props) => {
+  const { control, formState, register, setValue, handleSubmit } =
+    useForm<FormField>();
+
+  const { errors } = formState;
+
+  const { field: categoryField } = useController({
+    name: "category",
+    control,
+    rules: {
+      required: "하나 이상의 카테고리를 선택해주세요",
+    },
+  });
+
+  const { field: publicVisibleField } = useController({
+    name: "publicVisible",
+  });
+
+  return (
+    <form id={formId} className="space-y-4" onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <RequiredLabel htmlFor="name">카드셋명</RequiredLabel>
+        <Input
+          id="name"
+          {...register("name", { required: "카드셋명을 입력해주세요" })}
+        />
+        {!!errors.name && <ErrorMessage>{errors.name.message}</ErrorMessage>}
+      </div>
+
+      <div className="flex gap-2">
+        <Checkbox
+          id="publicVisible"
+          checked={publicVisibleField.value}
+          onCheckedChange={publicVisibleField.onChange}
+        />
+        <RequiredLabel htmlFor="publicVisible">공개여부</RequiredLabel>
+      </div>
+
+      <div>
+        <RequiredLabel>카테고리</RequiredLabel>
+        <Description>하나 이상의 카테고리를 선택해주세요</Description>
+        <ButtonCheckboxGroupField
+          name="category"
+          value={categoryField.value}
+          onChange={categoryField.onChange}
+          onBlur={categoryField.onBlur}
+        >
+          {Object.entries(GROUP_CATEGORY_MAP).map(([value, name]) => (
+            <ButtonCheckbox key={value} value={value}>
+              {name}
+            </ButtonCheckbox>
+          ))}
+        </ButtonCheckboxGroupField>
+        {!!errors.category && (
+          <ErrorMessage>{errors.category.message}</ErrorMessage>
+        )}
+      </div>
+
+      <div>
+        <Label htmlFor="image" className="mb-2">
+          이미지
+        </Label>
+        <Input
+          id="image"
+          type="file"
+          onChange={async (e: ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0];
+
+            if (!file) return;
+
+            const imageRefId = await uploadImage({ file, type: "GROUP" });
+            if (imageRefId) setValue("imageRefId", imageRefId);
+          }}
+        />
+      </div>
+    </form>
+  );
+};
+
+export default CardsetCreateForm;

--- a/src/features/cardset/components/CardsetCreateForm.tsx
+++ b/src/features/cardset/components/CardsetCreateForm.tsx
@@ -3,20 +3,22 @@ import {
   ButtonCheckbox,
   ButtonCheckboxGroupField,
 } from "@/shared/components/button-checkbox";
+import { Button } from "@/shared/components/button";
 import { Checkbox } from "@/shared/components/checkbox";
 import { ErrorMessage, RequiredLabel } from "@/shared/components/form";
 import { Input } from "@/shared/components/input";
 import { Label } from "@/shared/components/label";
 import { uploadImage } from "@/shared/lib/upload-image";
 import { Description } from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
 import type { ChangeEvent } from "react";
-import { useController, useForm } from "react-hook-form";
+import { useController, useFieldArray, useForm } from "react-hook-form";
 
 export type CardsetCreateFormField = {
   name: string;
   publicVisible?: boolean;
   category: GroupCategory;
-  hashtag: string[];
+  hashtag: { name: string }[];
   imageRefId: number;
 };
 
@@ -27,7 +29,11 @@ type Props = {
 
 const CardsetCreateForm = ({ onSubmit, formId = "cardset-form" }: Props) => {
   const { control, formState, register, setValue, handleSubmit } =
-    useForm<CardsetCreateFormField>();
+    useForm<CardsetCreateFormField>({
+      defaultValues: {
+        hashtag: [],
+      },
+    });
 
   const { errors } = formState;
 
@@ -41,6 +47,12 @@ const CardsetCreateForm = ({ onSubmit, formId = "cardset-form" }: Props) => {
 
   const { field: publicVisibleField } = useController({
     name: "publicVisible",
+    control,
+  });
+
+  const { fields, append, remove } = useFieldArray<CardsetCreateFormField>({
+    name: "hashtag",
+    control,
   });
 
   return (
@@ -99,6 +111,38 @@ const CardsetCreateForm = ({ onSubmit, formId = "cardset-form" }: Props) => {
             if (imageRefId) setValue("imageRefId", imageRefId);
           }}
         />
+      </div>
+
+      <div>
+        <Label className="mb-2">해시태그</Label>
+        <div className="space-y-2">
+          {fields.map((field, index) => (
+            <div key={field.id} className="flex gap-2 items-center">
+              <Input
+                {...register(`hashtag.${index}.name` as const, {
+                  required: "해시태그를 입력해주세요",
+                })}
+                placeholder="해시태그 입력"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => remove(index)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => append({ name: "" })}
+            className="w-full"
+          >
+            해시태그 추가
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/src/features/cardset/components/CardsetCreateForm.tsx
+++ b/src/features/cardset/components/CardsetCreateForm.tsx
@@ -12,7 +12,7 @@ import { Description } from "@radix-ui/react-dialog";
 import type { ChangeEvent } from "react";
 import { useController, useForm } from "react-hook-form";
 
-type FormField = {
+export type CardsetCreateFormField = {
   name: string;
   publicVisible?: boolean;
   category: GroupCategory;
@@ -21,13 +21,13 @@ type FormField = {
 };
 
 type Props = {
-  onSubmit: (form: FormField) => void;
+  onSubmit: (form: CardsetCreateFormField) => void;
   formId?: string;
 };
 
 const CardsetCreateForm = ({ onSubmit, formId = "cardset-form" }: Props) => {
   const { control, formState, register, setValue, handleSubmit } =
-    useForm<FormField>();
+    useForm<CardsetCreateFormField>();
 
   const { errors } = formState;
 

--- a/src/pages/group-detail.tsx
+++ b/src/pages/group-detail.tsx
@@ -14,6 +14,7 @@ import { CardsetCard } from "@/domain/cardsets/components/CardsetCard";
 import { useGroupDetail } from "@/domain/group/hooks/useGroupDetail";
 import { useGroupMembers } from "@/domain/members/hooks/useGroupMembers";
 import { useGroupCardsets } from "@/domain/cardsets/hooks/useGroupCardsets";
+import CardsetCreateDialog from "@/features/cardset/components/CardsetCreateDialog";
 
 type Props = { id: string };
 
@@ -102,10 +103,15 @@ const GroupDetailPage = ({ id }: Props) => {
           <div className="mb-4 flex items-center justify-between">
             <h2 className="text-2xl font-bold">카드셋</h2>
             {hasManagePermission && (
-              <Button size="sm" variant="outline">
-                <Plus className="size-4" />
-                카드셋 생성
-              </Button>
+              <CardsetCreateDialog
+                groupId={groupId}
+                renderTrigger={
+                  <Button size="sm" variant="outline">
+                    <Plus className="size-4" />
+                    카드셋 생성
+                  </Button>
+                }
+              />
             )}
           </div>
           {cardSets.length > 0 ? (

--- a/src/shared/apis/card-set.ts
+++ b/src/shared/apis/card-set.ts
@@ -33,7 +33,7 @@ export interface CreateCardSetRequest {
   publicVisible: boolean;
   category: GroupCategory;
   hashtag: string[];
-  imageRefId: string;
+  imageRefId?: number;
 }
 
 export interface CreateCardSetResponse {

--- a/src/shared/apis/card-set.ts
+++ b/src/shared/apis/card-set.ts
@@ -33,7 +33,7 @@ export interface CreateCardSetRequest {
   publicVisible: boolean;
   category: GroupCategory;
   hashtag: string[];
-  image?: string;
+  imageRefId: string;
 }
 
 export interface CreateCardSetResponse {
@@ -56,13 +56,19 @@ export interface CardSetSearchRequest extends PaginationRequest {
 export const cardSetApi = {
   // 카드셋 목록 조회(검색)
   getCardSets: (params: CardSetSearchRequest) =>
-    apiClient.get<ApiResponse<PagingResponse<CardSetSummaryResponse>>>("/card-sets", {
-      params,
-    }),
+    apiClient.get<ApiResponse<PagingResponse<CardSetSummaryResponse>>>(
+      "/card-sets",
+      {
+        params,
+      }
+    ),
 
   // 카드셋 생성
   createCardSet: (groupId: number, data: CreateCardSetRequest) =>
-    apiClient.post<ApiResponse<CreateCardSetResponse>>(`/groups/${groupId}/card-sets`, data),
+    apiClient.post<ApiResponse<CreateCardSetResponse>>(
+      `/groups/${groupId}/card-sets`,
+      data
+    ),
 
   // 카드셋 상세 조회
   getCardSet: (groupId: number, cardSetId: number) =>

--- a/src/shared/components/dialog.tsx
+++ b/src/shared/components/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/shared/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카드셋 생성 다이얼로그 추가: 그룹 내에서 카드셋 생성 흐름을 대화형으로 제공
  * 카드셋 생성 폼 개선: 이미지 업로드, 공개 설정, 카테고리 선택, 해시태그 추가/삭제 지원

* **기타**
  * macOS 호환성 개선: 스크립트의 인플레이스 편집 호환성 향상
  * 공용 UI 컴포넌트 추가: 대화상자(Dialog) 구성 요소 도입으로 재사용성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->