### PR TITLE
Fn 128 group join management

### DIFF
--- a/src/domain/group/components/GroupJoinDialog.tsx
+++ b/src/domain/group/components/GroupJoinDialog.tsx
@@ -12,7 +12,6 @@ import { Button } from "@/shared/components/button";
 import { Textarea } from "@/shared/components/textarea";
 import { Label } from "@/shared/components/label";
 import { useGroupJoin } from "@/domain/group/hooks/useGroupJoin";
-import { useToast } from "@/shared/hooks/use-toast";
 
 type GroupJoinDialogProps = {
   groupId: number;
@@ -28,7 +27,6 @@ export const GroupJoinDialog = ({
   const [open, setOpen] = useState(false);
   const [joinIntro, setJoinIntro] = useState("");
   const { mutate: joinGroup, isPending } = useGroupJoin();
-  const { toast } = useToast();
 
   const handleSubmit = () => {
     joinGroup(
@@ -38,19 +36,14 @@ export const GroupJoinDialog = ({
       },
       {
         onSuccess: () => {
-          toast({
-            title: "가입 신청 완료",
-            description: `${groupName} 그룹에 가입 신청했습니다.`,
-          });
+          window.alert(`${groupName} 그룹에 가입 신청했습니다.`);
           setOpen(false);
           setJoinIntro("");
         },
         onError: (error: any) => {
-          toast({
-            title: "가입 신청 실패",
-            description: error?.response?.data?.message || "가입 신청에 실패했습니다.",
-            variant: "destructive",
-          });
+          window.alert(
+            error?.response?.data?.message || "가입 신청에 실패했습니다."
+          );
         },
       }
     );

--- a/src/domain/group/components/GroupJoinDialog.tsx
+++ b/src/domain/group/components/GroupJoinDialog.tsx
@@ -12,6 +12,8 @@ import { Button } from "@/shared/components/button";
 import { Textarea } from "@/shared/components/textarea";
 import { Label } from "@/shared/components/label";
 import { useGroupJoin } from "@/domain/group/hooks/useGroupJoin";
+import useAuthStore from "@/stores/useAuthStore";
+import { useNavigate } from "@tanstack/react-router";
 
 type GroupJoinDialogProps = {
   groupId: number;
@@ -26,7 +28,22 @@ export const GroupJoinDialog = ({
 }: GroupJoinDialogProps) => {
   const [open, setOpen] = useState(false);
   const [joinIntro, setJoinIntro] = useState("");
+  const user = useAuthStore((state) => state.user);
+  const navigate = useNavigate();
   const { mutate: joinGroup, isPending } = useGroupJoin();
+
+  const handleOpenChange = (newOpen: boolean) => {
+    // 로그인 체크: 모달을 열려고 할 때 로그인되지 않았으면 로그인 페이지로
+    if (newOpen && !user) {
+      const currentUrl = window.location.href;
+      navigate({
+        to: "/auth/login",
+        search: { redirect: currentUrl },
+      });
+      return;
+    }
+    setOpen(newOpen);
+  };
 
   const handleSubmit = () => {
     joinGroup(
@@ -50,7 +67,7 @@ export const GroupJoinDialog = ({
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>

--- a/src/domain/group/components/GroupJoinDialog.tsx
+++ b/src/domain/group/components/GroupJoinDialog.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/shared/components/dialog";
+import { Button } from "@/shared/components/button";
+import { Textarea } from "@/shared/components/textarea";
+import { Label } from "@/shared/components/label";
+import { useGroupJoin } from "@/domain/group/hooks/useGroupJoin";
+import { useToast } from "@/shared/hooks/use-toast";
+
+type GroupJoinDialogProps = {
+  groupId: number;
+  groupName: string;
+  children: React.ReactNode;
+};
+
+export const GroupJoinDialog = ({
+  groupId,
+  groupName,
+  children,
+}: GroupJoinDialogProps) => {
+  const [open, setOpen] = useState(false);
+  const [joinIntro, setJoinIntro] = useState("");
+  const { mutate: joinGroup, isPending } = useGroupJoin();
+  const { toast } = useToast();
+
+  const handleSubmit = () => {
+    joinGroup(
+      {
+        groupId,
+        data: { joinIntro: joinIntro || undefined },
+      },
+      {
+        onSuccess: () => {
+          toast({
+            title: "가입 신청 완료",
+            description: `${groupName} 그룹에 가입 신청했습니다.`,
+          });
+          setOpen(false);
+          setJoinIntro("");
+        },
+        onError: (error: any) => {
+          toast({
+            title: "가입 신청 실패",
+            description: error?.response?.data?.message || "가입 신청에 실패했습니다.",
+            variant: "destructive",
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>그룹 가입 신청</DialogTitle>
+          <DialogDescription>
+            {groupName} 그룹에 가입을 신청합니다.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="joinIntro">가입 인사 (선택)</Label>
+            <Textarea
+              id="joinIntro"
+              placeholder="그룹장에게 전달할 가입 인사를 작성해주세요."
+              value={joinIntro}
+              onChange={(e) => setJoinIntro(e.target.value)}
+              rows={4}
+              className="resize-none"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+          >
+            취소
+          </Button>
+          <Button type="submit" onClick={handleSubmit} disabled={isPending}>
+            {isPending ? "신청 중..." : "가입 신청"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/domain/group/hooks/useGroupJoin.ts
+++ b/src/domain/group/hooks/useGroupJoin.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { groupJoinApi } from "@/shared/apis/group-join";
+import type { GroupJoinRequest } from "@/shared/apis/group-join";
+
+export const useGroupJoin = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ groupId, data }: { groupId: number; data?: GroupJoinRequest }) =>
+      groupJoinApi.joinRequest(groupId, data),
+    onSuccess: () => {
+      // 가입 신청 목록 갱신
+      queryClient.invalidateQueries({ queryKey: ["groups", "joins"] });
+      queryClient.invalidateQueries({ queryKey: ["groups", "joins", "me"] });
+    },
+  });
+};
+
+export const useCancelGroupJoin = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ groupId, joinId }: { groupId: number; joinId: number }) =>
+      groupJoinApi.deleteJoinRequest(groupId, joinId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["groups", "joins"] });
+      queryClient.invalidateQueries({ queryKey: ["groups", "joins", "me"] });
+    },
+  });
+};

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/shared/components/button";
 import { Label } from "@/shared/components/label";
 import { Separator } from "@/shared/components/separator";
 import { authApi, type UserLoginRequest } from "@/shared/apis";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { useMutation } from "@tanstack/react-query";
 import useAuthStore from "@/stores/useAuthStore";
@@ -18,13 +18,21 @@ type FieldState = UserLoginRequest;
 
 const Login = () => {
   const navigate = useNavigate({ from: "/auth/register" });
+  const search = useSearch({ from: "/auth/login" });
+  const redirectUrl = search.redirect as string | undefined;
+
   const { getValues, register } = useForm<FieldState>({});
   const updateAccessToken = useAuthStore((state) => state.updateAccessToken);
   const { mutate: login } = useMutation({
     mutationFn: authApi.login,
-    onSuccess: (res) => {
-      updateAccessToken(res.data.data.accessToken);
-      navigate({ to: "/" });
+    onSuccess: async (res) => {
+      await updateAccessToken(res.data.data.accessToken);
+      // redirect 파라미터가 있으면 해당 페이지로, 없으면 홈으로
+      if (redirectUrl) {
+        window.location.href = redirectUrl;
+      } else {
+        navigate({ to: "/" });
+      }
     },
   });
 

--- a/src/pages/cardset-detail.tsx
+++ b/src/pages/cardset-detail.tsx
@@ -5,7 +5,6 @@ import { Label } from "@/shared/components/label";
 import { useQuery } from "@tanstack/react-query";
 import { useGroupMembers } from "@/domain/members/hooks/useGroupMembers";
 import useAuthStore from "@/stores/useAuthStore";
-import { useToast } from "@/shared/hooks/use-toast";
 import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
@@ -16,7 +15,6 @@ type Props = {
 
 const CardsetDetail = ({ groupId, cardsetId }: Props) => {
   const user = useAuthStore((state) => state.user);
-  const { toast } = useToast();
   const navigate = useNavigate();
 
   const { data } = useQuery({
@@ -40,14 +38,10 @@ const CardsetDetail = ({ groupId, cardsetId }: Props) => {
   // 카드셋 접근 제어: 공개 + 가입 승인 필수인 그룹의 경우 멤버가 아니면 접근 불가
   useEffect(() => {
     if (group && !isMember && group.publicVisible && group.applicationRequired) {
-      toast({
-        title: "그룹 가입이 필요합니다",
-        description: "이 카드셋을 보려면 그룹에 가입 신청을 해주세요.",
-        variant: "destructive",
-      });
+      window.alert("이 카드셋을 보려면 그룹에 가입 신청을 해주세요.");
       navigate({ to: `/groups/${groupId}` });
     }
-  }, [group, isMember, groupId, navigate, toast]);
+  }, [group, isMember, groupId, navigate]);
 
   if (!cardset) return null;
 

--- a/src/pages/cardset-detail.tsx
+++ b/src/pages/cardset-detail.tsx
@@ -1,8 +1,13 @@
 import { GROUP_CATEGORY_MAP } from "@/domain/group/types";
-import { cardSetApi } from "@/shared/apis";
+import { cardSetApi, groupApi } from "@/shared/apis";
 import { Button } from "@/shared/components/button";
 import { Label } from "@/shared/components/label";
 import { useQuery } from "@tanstack/react-query";
+import { useGroupMembers } from "@/domain/members/hooks/useGroupMembers";
+import useAuthStore from "@/stores/useAuthStore";
+import { useToast } from "@/shared/hooks/use-toast";
+import { useEffect } from "react";
+import { useNavigate } from "@tanstack/react-router";
 
 type Props = {
   groupId: number;
@@ -10,12 +15,39 @@ type Props = {
 };
 
 const CardsetDetail = ({ groupId, cardsetId }: Props) => {
+  const user = useAuthStore((state) => state.user);
+  const { toast } = useToast();
+  const navigate = useNavigate();
+
   const { data } = useQuery({
     queryKey: ["cardset", groupId, cardsetId],
     queryFn: () => cardSetApi.getCardSet(groupId, cardsetId),
   });
 
+  const { data: groupData } = useQuery({
+    queryKey: ["group", groupId],
+    queryFn: () => groupApi.getGroupDetail(groupId),
+  });
+
+  const { data: members = [] } = useGroupMembers(groupId);
+
   const cardset = data?.data.data;
+  const group = groupData?.data.data;
+
+  // 현재 사용자가 그룹 멤버인지 확인
+  const isMember = members.some((member) => member.id === user?.userId);
+
+  // 카드셋 접근 제어: 공개 + 가입 승인 필수인 그룹의 경우 멤버가 아니면 접근 불가
+  useEffect(() => {
+    if (group && !isMember && group.publicVisible && group.applicationRequired) {
+      toast({
+        title: "그룹 가입이 필요합니다",
+        description: "이 카드셋을 보려면 그룹에 가입 신청을 해주세요.",
+        variant: "destructive",
+      });
+      navigate({ to: `/groups/${groupId}` });
+    }
+  }, [group, isMember, groupId, navigate, toast]);
 
   if (!cardset) return null;
 

--- a/src/pages/cardset-list.tsx
+++ b/src/pages/cardset-list.tsx
@@ -151,8 +151,11 @@ const CardSetList = () => {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {cardsetsData?.cardsets.map((cardset) => (
             <Link
-              to="/cardsets/$id"
-              params={{ id: cardset.cardSetId.toString() }}
+              to="/groups/$groupId/cardsets/$cardsetId"
+              params={{
+                groupId: cardset.groupId.toString(),
+                cardsetId: cardset.cardSetId.toString(),
+              }}
               key={cardset.cardSetId}
             >
               <Card className="overflow-hidden hover:shadow-lg transition-shadow duration-200 cursor-pointer">

--- a/src/pages/group-detail.tsx
+++ b/src/pages/group-detail.tsx
@@ -62,6 +62,27 @@ const GroupDetailPage = ({ id }: Props) => {
     );
   }
 
+  // 비공개 그룹 접근 제어: 멤버가 아니면 접근 불가
+  if (!groupData.publicVisible && !isMember) {
+    return (
+      <BaseLayout>
+        <div className="mx-auto max-w-6xl p-6">
+          <div className="text-center space-y-4">
+            <h2 className="text-2xl font-bold text-gray-900">
+              비공개 그룹입니다
+            </h2>
+            <p className="text-muted-foreground">
+              이 그룹은 비공개 그룹으로 멤버만 접근할 수 있습니다.
+            </p>
+            <Button onClick={() => window.history.back()} variant="outline">
+              돌아가기
+            </Button>
+          </div>
+        </div>
+      </BaseLayout>
+    );
+  }
+
   return (
     <BaseLayout>
       <div className="mx-auto max-w-6xl space-y-8 p-6">

--- a/src/pages/group-detail.tsx
+++ b/src/pages/group-detail.tsx
@@ -1,4 +1,4 @@
-import { Plus } from "lucide-react";
+import { Plus, UserPlus } from "lucide-react";
 import { Button } from "@/shared/components/button";
 import {
   Carousel,
@@ -15,11 +15,14 @@ import { useGroupDetail } from "@/domain/group/hooks/useGroupDetail";
 import { useGroupMembers } from "@/domain/members/hooks/useGroupMembers";
 import { useGroupCardsets } from "@/domain/cardsets/hooks/useGroupCardsets";
 import CardsetCreateDialog from "@/features/cardset/components/CardsetCreateDialog";
+import { GroupJoinDialog } from "@/domain/group/components/GroupJoinDialog";
+import useAuthStore from "@/stores/useAuthStore";
 
 type Props = { id: string };
 
 const GroupDetailPage = ({ id }: Props) => {
   const groupId = Number(id);
+  const user = useAuthStore((state) => state.user);
 
   const { data: groupData, isLoading: isGroupLoading } =
     useGroupDetail(groupId);
@@ -28,7 +31,12 @@ const GroupDetailPage = ({ id }: Props) => {
   const { data: cardSets = [], isLoading: isCardsetsLoading } =
     useGroupCardsets(groupId);
 
+  // 현재 사용자가 그룹 멤버인지 확인
+  const isMember = members.some((member) => member.id === user?.userId);
   const hasManagePermission = true; // TODO: 실제로는 사용자 권한 체크
+
+  // 가입 신청 버튼 표시 여부 (멤버가 아니고 가입 승인이 필요한 그룹)
+  const showJoinButton = !isMember && groupData?.applicationRequired;
 
   const isLoading = isGroupLoading || isMembersLoading || isCardsetsLoading;
 
@@ -64,12 +72,22 @@ const GroupDetailPage = ({ id }: Props) => {
         <section>
           <div className="mb-4 flex items-center justify-between">
             <h2 className="text-2xl font-bold">멤버</h2>
-            {hasManagePermission && (
-              <Button size="sm" variant="outline">
-                <Plus className="size-4" />
-                멤버 초대
-              </Button>
-            )}
+            <div className="flex gap-2">
+              {showJoinButton && (
+                <GroupJoinDialog groupId={groupId} groupName={groupData.name}>
+                  <Button size="sm" variant="default">
+                    <UserPlus className="size-4" />
+                    가입신청
+                  </Button>
+                </GroupJoinDialog>
+              )}
+              {hasManagePermission && (
+                <Button size="sm" variant="outline">
+                  <Plus className="size-4" />
+                  멤버 초대
+                </Button>
+              )}
+            </div>
           </div>
           {members.length > 0 ? (
             <Carousel

--- a/src/routes/auth/login.tsx
+++ b/src/routes/auth/login.tsx
@@ -7,6 +7,11 @@ export const Route = createFileRoute("/auth/login")({
   beforeLoad: ({ context }) => {
     authGuard({ auth: context.auth, mode: "non-protected" });
   },
+  validateSearch: (search: Record<string, unknown>) => {
+    return {
+      redirect: (search.redirect as string) || undefined,
+    };
+  },
 });
 
 function RouteComponent() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  - 카드셋 목록 페이지: 검색, 카테고리 필터링, 정렬 기능 및 무한 스크롤 지원
  - 그룹 가입 신청 기능 추가
  - 로그인 후 이전 페이지로 자동 리다이렉트

* **개선사항**
  - 그룹 액세스 제어 강화: 프라이빗 그룹은 멤버만 접근 가능
  - 카드셋 상세 페이지에 그룹 멤버 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->