### PR TITLE
feat: [FN-88] 회원탈퇴 연동

### DIFF
--- a/src/domain/user/components/user-profile-view.tsx
+++ b/src/domain/user/components/user-profile-view.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/shared/components/button";
 import { Label } from "@/shared/components/label";
 import type { MyInfoResponse } from "@/shared/apis/user";
 import SocialAccountSection from "@/features/social-link/components/social-account-section";
+import WithdrawDialog from "@/features/mypage/components/withdraw-dialog";
 
 type Props = {
   userInfo: MyInfoResponse;
@@ -55,6 +56,8 @@ const UserProfileView = ({ userInfo, onEditClick }: Props) => {
           </div>
 
           <SocialAccountSection />
+
+          <WithdrawDialog />
         </CardContent>
       </Card>
     </div>

--- a/src/features/mypage/components/withdraw-dialog.tsx
+++ b/src/features/mypage/components/withdraw-dialog.tsx
@@ -1,0 +1,84 @@
+import { userApi } from "@/shared/apis";
+import { Button } from "@/shared/components/button";
+import {
+  DialogClose,
+  DialogDescription,
+  DialogHeader,
+} from "@/shared/components/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/shared/components/dialog";
+import { Input } from "@/shared/components/input";
+import { useMutation } from "@tanstack/react-query";
+import { useState, type ChangeEvent } from "react";
+
+const CONFIRM_TEXT = "탈퇴";
+
+const WithdrawDialog = () => {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState("");
+
+  const { isPending, mutate } = useMutation({
+    mutationFn: userApi.withdrawUser,
+    onSuccess: () => {
+      setOpen(false);
+      setValue("");
+    },
+    onError: (error) => {
+      console.log("ERROR", error);
+    },
+  });
+
+  const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  const handleSubmit = async () => {
+    mutate();
+  };
+
+  const activeConfirmButton = value === CONFIRM_TEXT;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="link">회원탈퇴하기</Button>
+      </DialogTrigger>
+      <DialogContent onInteractOutside={(e) => e.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>회원탈퇴</DialogTitle>
+          <DialogDescription>
+            회원탈퇴를 위해서는 아래에 '{CONFIRM_TEXT}'를 입력해주세요
+          </DialogDescription>
+        </DialogHeader>
+
+        <Input
+          placeholder={CONFIRM_TEXT}
+          value={value}
+          onChange={handleChangeInput}
+        />
+
+        <div className="text-right space-x-2">
+          <DialogClose asChild>
+            <Button type="reset" variant={"outline"} disabled={isPending}>
+              취소
+            </Button>
+          </DialogClose>
+
+          <Button
+            type="submit"
+            disabled={!activeConfirmButton || isPending}
+            onClick={handleSubmit}
+          >
+            탈퇴
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default WithdrawDialog;

--- a/src/features/mypage/components/withdraw-dialog.tsx
+++ b/src/features/mypage/components/withdraw-dialog.tsx
@@ -12,23 +12,33 @@ import {
   DialogTrigger,
 } from "@/shared/components/dialog";
 import { Input } from "@/shared/components/input";
+import useAuthStore from "@/stores/useAuthStore";
 import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { useState, type ChangeEvent } from "react";
 
 const CONFIRM_TEXT = "탈퇴";
 
 const WithdrawDialog = () => {
+  const navigate = useNavigate();
+
+  const { clearUser } = useAuthStore();
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState("");
 
   const { isPending, mutate } = useMutation({
     mutationFn: userApi.withdrawUser,
     onSuccess: () => {
+      clearUser();
       setOpen(false);
       setValue("");
+
+      navigate({ to: "/" });
     },
     onError: (error) => {
       console.log("ERROR", error);
+
+      window.alert("회원탈퇴에 실패했습니다. 다시 시도해주세요.");
     },
   });
 


### PR DESCRIPTION
회원 탈퇴 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 프로필에 회원탈퇴 기능을 추가했습니다.
  * 탈퇴 모달에서 지정된 확인 텍스트를 정확히 입력해야만 버튼이 활성화되어 실수를 방지합니다.
  * 탈퇴 완료 시 자동으로 홈 화면으로 이동하고 인증 상태가 정리됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->