### PR TITLE
feat: [FN-311] 카드셋 삭제 API 연동

### DIFF
--- a/src/pages/cardset-detail.tsx
+++ b/src/pages/cardset-detail.tsx
@@ -35,7 +35,7 @@ const CardsetDetail = ({ groupId, cardsetId }: Props) => {
     queryFn: () => groupApi.getGroupDetail(groupId),
   });
 
-  const { mutate } = useMutation({
+  const { mutate, isPending } = useMutation({
     mutationFn: () => cardSetApi.deleteCardSet(groupId, cardsetId),
     onSuccess: () => {
       alert("카드셋 삭제에 성공했습니다.");
@@ -191,7 +191,11 @@ const CardsetDetail = ({ groupId, cardsetId }: Props) => {
               cardset={cardset}
               renderTrigger={<Button variant="outline">수정</Button>}
             />
-            <Button variant="outline" onClick={handleClickDelete}>
+            <Button
+              variant="outline"
+              disabled={isPending}
+              onClick={handleClickDelete}
+            >
               삭제
             </Button>
           </div>

--- a/src/pages/cardset-detail.tsx
+++ b/src/pages/cardset-detail.tsx
@@ -1,7 +1,7 @@
 import { GROUP_CATEGORY_MAP } from "@/domain/group/types";
 import { cardSetApi, groupApi } from "@/shared/apis";
 import { Button } from "@/shared/components/button";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useGroupMembers } from "@/domain/members/hooks/use-group-members";
 import useAuthStore from "@/stores/use-auth-store";
 import { useEffect } from "react";
@@ -33,6 +33,17 @@ const CardsetDetail = ({ groupId, cardsetId }: Props) => {
   const { data: groupData } = useQuery({
     queryKey: ["group", groupId],
     queryFn: () => groupApi.getGroupDetail(groupId),
+  });
+
+  const { mutate } = useMutation({
+    mutationFn: () => cardSetApi.deleteCardSet(groupId, cardsetId),
+    onSuccess: () => {
+      alert("카드셋 삭제에 성공했습니다.");
+      navigate({ to: "/cardset-list" });
+    },
+    onError: () => {
+      alert("카드셋 삭제를 실패했습니다.");
+    },
   });
 
   const { data: members = [] } = useGroupMembers(groupId);
@@ -87,6 +98,9 @@ const CardsetDetail = ({ groupId, cardsetId }: Props) => {
 
   const hashtags = cardset.hashtag ? cardset.hashtag.split(",") : [];
 
+  const handleClickDelete = () => {
+    mutate();
+  };
   return (
     <BaseLayout>
       <div className="mx-auto p-6 flex flex-col sm:flex-row gap-6 justify-between">
@@ -177,7 +191,9 @@ const CardsetDetail = ({ groupId, cardsetId }: Props) => {
               cardset={cardset}
               renderTrigger={<Button variant="outline">수정</Button>}
             />
-            <Button variant="outline">삭제</Button>
+            <Button variant="outline" onClick={handleClickDelete}>
+              삭제
+            </Button>
           </div>
         </div>
       </div>

--- a/src/shared/apis/card-set.ts
+++ b/src/shared/apis/card-set.ts
@@ -67,37 +67,42 @@ export const cardSetApi = {
       "/card-sets",
       {
         params,
-      }
+      },
     ),
 
   // 그룹의 카드셋 목록 조회
   getGroupCardSets: (groupId: number, params?: PaginationRequest) =>
     apiClient.get<ApiResponse<PagingResponse<CardSetSummaryResponse>>>(
       `/groups/${groupId}/card-sets`,
-      { params }
+      { params },
     ),
 
   // 카드셋 생성
   createCardSet: (groupId: number, data: CreateCardSetRequest) =>
     apiClient.post<ApiResponse<CreateCardSetResponse>>(
       `/groups/${groupId}/card-sets`,
-      data
+      // @TODO 매니저 넣는 필드 실제로 추가해야 함.
+      { managers: [3], ...data },
     ),
 
   // 카드셋 상세 조회
   getCardSet: (groupId: number, cardSetId: number) =>
     apiClient.get<ApiResponse<CardSetDetailResponse>>(
-      `/groups/${groupId}/card-sets/${cardSetId}`
+      `/groups/${groupId}/card-sets/${cardSetId}`,
     ),
 
   // 카드셋 수정
   updateCardSet: (
     groupId: number,
     cardSetId: number,
-    data: CardSetUpdateRequest
+    data: CardSetUpdateRequest,
   ) =>
     apiClient.put<ApiResponse<CardSetDetailResponse>>(
       `/groups/${groupId}/card-sets/${cardSetId}`,
-      data
+      data,
     ),
+
+  // 카드셋 삭제
+  deleteCardSet: (groupId: number, cardSetId: number) =>
+    apiClient.delete<ApiResponse>(`/groups/${groupId}/card-sets/${cardSetId}`),
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 카드셋 삭제 기능이 추가되었습니다. 카드셋 상세 페이지에서 삭제 버튼으로 삭제할 수 있습니다.
* 삭제 처리 중에는 삭제 버튼이 비활성화되어 중복 요청을 방지합니다.
* 삭제 성공 시 확인 메시지 표시 후 카드셋 목록으로 자동 이동하고, 실패 시 오류 메시지를 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->