### PR TITLE
fix: [FN-344]production으로 빌드 시 FCM토큰 스크립트에 환경변수 삽입안되는 현상 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
 
       - name: Create .env file
-        run: echo "${{secrets.FE_ENV}}" > .env
+        run: echo "${{secrets.FE_ENV}}" > .env.production
 
       - name: Build React app
         run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Build React app
         run: npm run build
+        env:
+          NODE_ENV: production
 
       # AWS Credentials 설정
       - name: Configure AWS Credentials

--- a/scripts/generate-fcm-sw.js
+++ b/scripts/generate-fcm-sw.js
@@ -12,31 +12,37 @@ const envFile = path.resolve(__dirname, `../.env.${mode}`);
 console.log(`\n🔧 Generating Service Worker for ${mode} mode...`);
 
 // .env 파일 파싱
-const envConfig = {};
-if (fs.existsSync(envFile)) {
-  const envContent = fs.readFileSync(envFile, "utf-8");
-  envContent.split("\n").forEach((line) => {
+const parseEnvFile = (filePath) => {
+  const config = {};
+  if (!fs.existsSync(filePath)) return config;
+  const content = fs.readFileSync(filePath, "utf-8");
+  content.split("\n").forEach((line) => {
     const trimmed = line.trim();
     if (trimmed && !trimmed.startsWith("#")) {
       const [key, ...values] = trimmed.split("=");
-      if (key) {
-        envConfig[key.trim()] = values.join("=").trim();
-      }
+      if (key) config[key.trim()] = values.join("=").trim();
     }
   });
-} else {
-  console.warn(`⚠️  Warning: ${envFile} not found`);
-}
+  return config;
+};
 
-// Firebase 설정 추출
+// .env → .env.{mode} 순서로 읽어 병합 (mode 파일이 우선)
+const baseEnvFile = path.resolve(__dirname, "../.env");
+const baseConfig = parseEnvFile(baseEnvFile);
+const modeConfig = fs.existsSync(envFile)
+  ? parseEnvFile(envFile)
+  : (() => { console.warn(`⚠️  Warning: ${envFile} not found, falling back to .env`); return {}; })();
+const envConfig = { ...baseConfig, ...modeConfig };
+
+// Firebase 설정 추출 (process.env도 최종 fallback)
 const firebaseConfig = {
-  apiKey: envConfig.VITE_FIREBASE_API_KEY || "",
-  authDomain: envConfig.VITE_FIREBASE_AUTH_DOMAIN || "",
-  projectId: envConfig.VITE_FIREBASE_PROJECT_ID || "",
-  storageBucket: envConfig.VITE_FIREBASE_STORAGE_BUCKET || "",
-  messagingSenderId: envConfig.VITE_FIREBASE_MESSAGING_SENDER_ID || "",
-  appId: envConfig.VITE_FIREBASE_APP_ID || "",
-  measurementId: envConfig.VITE_FIREBASE_MEASUREMENT_ID || "",
+  apiKey: envConfig.VITE_FIREBASE_API_KEY || process.env.VITE_FIREBASE_API_KEY || "",
+  authDomain: envConfig.VITE_FIREBASE_AUTH_DOMAIN || process.env.VITE_FIREBASE_AUTH_DOMAIN || "",
+  projectId: envConfig.VITE_FIREBASE_PROJECT_ID || process.env.VITE_FIREBASE_PROJECT_ID || "",
+  storageBucket: envConfig.VITE_FIREBASE_STORAGE_BUCKET || process.env.VITE_FIREBASE_STORAGE_BUCKET || "",
+  messagingSenderId: envConfig.VITE_FIREBASE_MESSAGING_SENDER_ID || process.env.VITE_FIREBASE_MESSAGING_SENDER_ID || "",
+  appId: envConfig.VITE_FIREBASE_APP_ID || process.env.VITE_FIREBASE_APP_ID || "",
+  measurementId: envConfig.VITE_FIREBASE_MEASUREMENT_ID || process.env.VITE_FIREBASE_MEASUREMENT_ID || "",
 };
 
 // Service Worker 템플릿

--- a/scripts/generate-fcm-sw.js
+++ b/scripts/generate-fcm-sw.js
@@ -20,7 +20,12 @@ const parseEnvFile = (filePath) => {
     const trimmed = line.trim();
     if (trimmed && !trimmed.startsWith("#")) {
       const [key, ...values] = trimmed.split("=");
-      if (key) config[key.trim()] = values.join("=").trim();
+
+      if (key) {
+        const rawValue = values.join("=").trim();
+        const parsedValue = rawValue.replace(/^(['"])(.*)\1$/, "$2");
+        config[key.trim()] = parsedValue;
+      }
     }
   });
   return config;
@@ -31,18 +36,38 @@ const baseEnvFile = path.resolve(__dirname, "../.env");
 const baseConfig = parseEnvFile(baseEnvFile);
 const modeConfig = fs.existsSync(envFile)
   ? parseEnvFile(envFile)
-  : (() => { console.warn(`⚠️  Warning: ${envFile} not found, falling back to .env`); return {}; })();
+  : (() => {
+      console.warn(`⚠️  Warning: ${envFile} not found, falling back to .env`);
+      return {};
+    })();
 const envConfig = { ...baseConfig, ...modeConfig };
 
 // Firebase 설정 추출 (process.env도 최종 fallback)
 const firebaseConfig = {
-  apiKey: envConfig.VITE_FIREBASE_API_KEY || process.env.VITE_FIREBASE_API_KEY || "",
-  authDomain: envConfig.VITE_FIREBASE_AUTH_DOMAIN || process.env.VITE_FIREBASE_AUTH_DOMAIN || "",
-  projectId: envConfig.VITE_FIREBASE_PROJECT_ID || process.env.VITE_FIREBASE_PROJECT_ID || "",
-  storageBucket: envConfig.VITE_FIREBASE_STORAGE_BUCKET || process.env.VITE_FIREBASE_STORAGE_BUCKET || "",
-  messagingSenderId: envConfig.VITE_FIREBASE_MESSAGING_SENDER_ID || process.env.VITE_FIREBASE_MESSAGING_SENDER_ID || "",
-  appId: envConfig.VITE_FIREBASE_APP_ID || process.env.VITE_FIREBASE_APP_ID || "",
-  measurementId: envConfig.VITE_FIREBASE_MEASUREMENT_ID || process.env.VITE_FIREBASE_MEASUREMENT_ID || "",
+  apiKey:
+    envConfig.VITE_FIREBASE_API_KEY || process.env.VITE_FIREBASE_API_KEY || "",
+  authDomain:
+    envConfig.VITE_FIREBASE_AUTH_DOMAIN ||
+    process.env.VITE_FIREBASE_AUTH_DOMAIN ||
+    "",
+  projectId:
+    envConfig.VITE_FIREBASE_PROJECT_ID ||
+    process.env.VITE_FIREBASE_PROJECT_ID ||
+    "",
+  storageBucket:
+    envConfig.VITE_FIREBASE_STORAGE_BUCKET ||
+    process.env.VITE_FIREBASE_STORAGE_BUCKET ||
+    "",
+  messagingSenderId:
+    envConfig.VITE_FIREBASE_MESSAGING_SENDER_ID ||
+    process.env.VITE_FIREBASE_MESSAGING_SENDER_ID ||
+    "",
+  appId:
+    envConfig.VITE_FIREBASE_APP_ID || process.env.VITE_FIREBASE_APP_ID || "",
+  measurementId:
+    envConfig.VITE_FIREBASE_MEASUREMENT_ID ||
+    process.env.VITE_FIREBASE_MEASUREMENT_ID ||
+    "",
 };
 
 // Service Worker 템플릿
@@ -112,7 +137,7 @@ self.addEventListener("notificationclick", (event) => {
 // public 디렉토리에 Service Worker 파일 생성
 const outputPath = path.resolve(
   __dirname,
-  "../public/firebase-messaging-sw.js"
+  "../public/firebase-messaging-sw.js",
 );
 fs.writeFileSync(outputPath, swTemplate, "utf-8");
 


### PR DESCRIPTION
- 환경변수 파일명 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우가 프로덕션용 환경 파일(.env.production)으로 설정되며 빌드 시 NODE_ENV가 production으로 설정됩니다.
  * 환경 파일 로드가 베이스 + 모드별 병합 방식으로 개선되어 모드 우선순위와 폴백 경고가 추가되었습니다.
  * Firebase 설정 추출이 병합된 환경 구성과 프로세스 환경변수 폴백을 사용하도록 강화되었으며, 서비스 워커 생성이 이 구성을 활용합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->