### PR TITLE
  chore: Playwright E2E 테스트 인프라 도입

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,6 @@
+# Playwright E2E 테스트용 자격증명
+# 이 파일을 .env.local로 복사 후 실제 값으로 채우세요.
+# .env.local은 gitignore되어 있어 안전합니다.
+
+E2E_TEST_EMAIL=
+E2E_TEST_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ public/firebase-messaging-sw.js
 *.njsproj
 *.sln
 *.sw?
+
+# AI 리팩토링 작업 노트 (로컬 전용)
+docs/refactoring/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ public/firebase-messaging-sw.js
 
 # AI 리팩토링 작업 노트 (로컬 전용)
 docs/refactoring/
+
+# Playwright E2E 산출물
+test-results/
+playwright-report/
+playwright/.cache/
+.auth/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,3 +269,18 @@ Required in `.env.development` and `.env.production`:
 5. **Code splitting**:
    - TanStack Router handles automatic route-based code splitting
    - No manual lazy loading needed for routes
+
+## Refactoring Rules (AI-Native Workflow)
+
+리팩토링 작업 시 다음 규칙을 따른다:
+
+1. **단일 항목 단일 PR**: `docs/refactoring/NN-*.md` 하나당 PR 하나
+2. **시작 시**: 해당 .md를 먼저 읽고, 체크리스트와 Done 기준을 `TodoWrite`로 등록
+3. **연관 문서 참조**: 작업 시작 전 `docs/architecture.md`, `docs/fsd-architecture-guide.md`, `docs/component-patterns.md`, `docs/component-reusability-guide.md` 중 관련 문서를 함께 읽어 기존 패턴을 우선 재사용
+4. **금지**: `any` 타입, 미사용 import, 주석 처리된 죽은 코드
+5. **네이밍**: 기존 코드 컨벤션 유지 (kebab-case 파일명, camelCase 변수)
+6. **커밋**: `fix:` / `feat:` / `refactor:` prefix만 사용. 브랜치명에 Jira 키(`XX-123`)가 있으면 `scripts/prepare-commit-jira.sh`가 자동 삽입
+7. **완료 기준 (husky pre-push와 동일)**:
+   - `npm run lint` 통과
+   - `npx tsc -b` 통과
+   - 해당 .md의 체크리스트 + 수동 검증 시나리오 전부 완료

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -13,15 +13,18 @@ type AuthFixtures = {
  * globalSetup이 .auth/user.json에 저장한 storageState를 사용한다.
  * 파일이 없으면(globalSetup 미실행 또는 자격증명 미설정) 명확한 에러로 실패.
  *
- * 사용:
+ * 사용 (`e2e/tests/*.spec.ts`에서):
  * ```ts
- * import { test, expect } from "@/e2e/fixtures/auth";
+ * import { test, expect } from "../fixtures/auth";
  *
  * test("로그인 상태에서 GNB 닉네임", async ({ authenticatedPage }) => {
  *   await authenticatedPage.goto("/");
  *   // ...
  * });
  * ```
+ *
+ * NOTE: `@/*` alias는 `./src/*`로 매핑되어 있어 e2e/ 내부 import에는 사용 불가.
+ * e2e 안에서는 상대 경로 사용. (별도 alias가 필요하면 e2e/tsconfig.json + playwright.config.ts에 추가)
  */
 export const test = base.extend<AuthFixtures>({
   authenticatedPage: async ({ browser }, use) => {

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,43 @@
+import { test as base, type Page } from "@playwright/test";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+const STORAGE_STATE_PATH = resolve(".auth/user.json");
+
+type AuthFixtures = {
+  authenticatedPage: Page;
+};
+
+/**
+ * 인증된 페이지 fixture.
+ *
+ * globalSetup이 .auth/user.json에 저장한 storageState를 사용한다.
+ * 파일이 없으면(globalSetup 미실행 또는 자격증명 미설정) 명확한 에러로 실패.
+ *
+ * 사용:
+ * ```ts
+ * import { test, expect } from "@/e2e/fixtures/auth";
+ *
+ * test("로그인 상태에서 GNB 닉네임", async ({ authenticatedPage }) => {
+ *   await authenticatedPage.goto("/");
+ *   // ...
+ * });
+ * ```
+ */
+export const test = base.extend<AuthFixtures>({
+  authenticatedPage: async ({ browser }, use) => {
+    if (!existsSync(STORAGE_STATE_PATH)) {
+      throw new Error(
+        `storageState 없음: ${STORAGE_STATE_PATH}\n` +
+          "globalSetup이 실행되었는지, .env.local에 E2E_TEST_EMAIL/E2E_TEST_PASSWORD가 있는지 확인.",
+      );
+    }
+    const context = await browser.newContext({
+      storageState: STORAGE_STATE_PATH,
+    });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,57 @@
+import { chromium } from "@playwright/test";
+import * as dotenv from "dotenv";
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+/**
+ * Playwright globalSetup.
+ *
+ * .env.local의 E2E_TEST_EMAIL/E2E_TEST_PASSWORD로 로그인 후 storageState를
+ * .auth/user.json 에 저장. authenticatedPage fixture가 이 파일을 사용한다.
+ *
+ * 환경변수가 없으면 인증 단계를 건너뛴다 (인증 필요 테스트는 명확한 에러로 실패).
+ */
+
+dotenv.config({ path: resolve(".env.local") });
+
+const STORAGE_STATE_DIR = resolve(".auth");
+const STORAGE_STATE_PATH = resolve(STORAGE_STATE_DIR, "user.json");
+const BASE_URL = "http://localhost:5173";
+
+async function globalSetup() {
+  const email = process.env.E2E_TEST_EMAIL;
+  const password = process.env.E2E_TEST_PASSWORD;
+
+  if (!email || !password) {
+    console.warn(
+      "[e2e] E2E_TEST_EMAIL / E2E_TEST_PASSWORD 미설정. 인증 단계 건너뜀.\n" +
+        "[e2e] authenticatedPage fixture를 쓰는 테스트는 실패합니다.\n" +
+        "[e2e] 해결: .env.local에 두 값을 추가.",
+    );
+    return;
+  }
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ baseURL: BASE_URL });
+
+  try {
+    const response = await context.request.post("/api/auth/login", {
+      data: { email, password },
+    });
+
+    if (!response.ok()) {
+      const body = await response.text();
+      throw new Error(
+        `[e2e] 로그인 실패: ${response.status()} ${response.statusText()}\n${body}`,
+      );
+    }
+
+    await mkdir(STORAGE_STATE_DIR, { recursive: true });
+    await context.storageState({ path: STORAGE_STATE_PATH });
+    console.log(`[e2e] 로그인 성공. storageState 저장: ${STORAGE_STATE_PATH}`);
+  } finally {
+    await browser.close();
+  }
+}
+
+export default globalSetup;

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -12,7 +12,9 @@ import { resolve } from "node:path";
  * 환경변수가 없으면 인증 단계를 건너뛴다 (인증 필요 테스트는 명확한 에러로 실패).
  */
 
+// .env.local 우선, 없으면 .env.development에서 fallback (dotenv 기본은 override 안 함)
 dotenv.config({ path: resolve(".env.local") });
+dotenv.config({ path: resolve(".env.development") });
 
 const STORAGE_STATE_DIR = resolve(".auth");
 const STORAGE_STATE_PATH = resolve(STORAGE_STATE_DIR, "user.json");

--- a/e2e/helpers/mock-api.ts
+++ b/e2e/helpers/mock-api.ts
@@ -1,0 +1,52 @@
+import type { Page } from "@playwright/test";
+
+// Playwright `page.route` 기반의 간이 API 모킹 helper.
+//
+// dev 서버가 `/api/*`를 백엔드로 proxy하는 구조이므로 같은 패턴으로 인터셉트한다.
+//
+// 사용:
+//   await mockApi(page).fail("**" + "/api/auth/login", 401, { message: "..." });
+//   await mockApi(page).succeed("**" + "/api/groups", { success: true, data: { ... } });
+export const mockApi = (page: Page) => ({
+  /** 지정된 패턴의 요청을 실패 응답으로 가로챈다. */
+  fail: (
+    urlPattern: string | RegExp,
+    status: number,
+    body: Record<string, unknown> = {},
+  ) =>
+    page.route(urlPattern, (route) =>
+      route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      }),
+    ),
+
+  /** 지정된 패턴의 요청을 성공 응답으로 가로챈다. */
+  succeed: (urlPattern: string | RegExp, body: Record<string, unknown>) =>
+    page.route(urlPattern, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      }),
+    ),
+
+  /** 커스텀 응답 (status·body·headers 임의 지정). */
+  respond: (
+    urlPattern: string | RegExp,
+    init: {
+      status?: number;
+      body?: Record<string, unknown>;
+      headers?: Record<string, string>;
+    },
+  ) =>
+    page.route(urlPattern, (route) =>
+      route.fulfill({
+        status: init.status ?? 200,
+        contentType: "application/json",
+        headers: init.headers,
+        body: JSON.stringify(init.body ?? {}),
+      }),
+    ),
+});

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -1,0 +1,29 @@
+import { test as anonymousTest, expect } from "@playwright/test";
+import { test as authTest } from "../fixtures/auth";
+
+/**
+ * Smoke 테스트 — 인프라 셋업이 동작하는지 확인.
+ *
+ * (a) 비로그인 상태로 /auth/login 진입 → 로그인 폼 보임
+ * (b) authenticatedPage로 / 진입 → "로그인" GNB 링크가 없어야 함 (로그인 상태 검증)
+ *
+ * (b)는 .env.local에 E2E_TEST_EMAIL / E2E_TEST_PASSWORD가 설정되어 있고
+ * 해당 계정이 백엔드에 존재해야 한다.
+ */
+
+anonymousTest("비로그인 - /auth/login 진입 시 로그인 폼 노출", async ({ page }) => {
+  await page.goto("/auth/login");
+  await expect(page.getByRole("textbox", { name: "이메일" })).toBeVisible();
+  // "비밀번호 보기" 토글 버튼과 라벨이 겹치므로 textbox로 한정
+  await expect(page.getByRole("textbox", { name: "비밀번호" })).toBeVisible();
+});
+
+authTest("로그인 - / 진입 시 GNB의 로그인 링크가 사라짐", async ({
+  authenticatedPage,
+}) => {
+  await authenticatedPage.goto("/");
+  // 인증되지 않았을 때만 보이는 GNB의 "로그인" 링크가 없어야 함
+  await expect(
+    authenticatedPage.getByRole("link", { name: "로그인" }),
+  ).toHaveCount(0);
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["@playwright/test", "node"],
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["**/*.ts", "../playwright.config.ts"]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,4 +20,17 @@ export default tseslint.config([
       globals: globals.browser,
     },
   },
+  // Playwright E2E 코드 — React가 아니므로 react-hooks 규칙 비활성
+  // (Playwright fixture의 `use` 콜백을 React Hook으로 오인하는 문제 회피)
+  {
+    files: ['e2e/**/*.{ts,tsx}', 'playwright.config.ts'],
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
+      'react-hooks/exhaustive-deps': 'off',
+      'react-refresh/only-export-components': 'off',
+    },
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,12 +45,14 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@playwright/test": "^1.59.1",
         "@tanstack/router-plugin": "^1.131.32",
         "@types/node": "^24.3.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@types/spark-md5": "^3.0.5",
         "@vitejs/plugin-react": "^5.0.0",
+        "dotenv": "^17.4.2",
         "eslint": "^9.33.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
@@ -1767,6 +1769,22 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -4533,6 +4551,19 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6117,6 +6148,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "build": "npm run generate:sw && tsc -b && vite build",
     "generate:sw": "node scripts/generate-fcm-sw.js",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -52,12 +55,14 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@playwright/test": "^1.59.1",
     "@tanstack/router-plugin": "^1.131.32",
     "@types/node": "^24.3.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@types/spark-md5": "^3.0.5",
     "@vitejs/plugin-react": "^5.0.0",
+    "dotenv": "^17.4.2",
     "eslint": "^9.33.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 5173;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e/tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "html",
+  globalSetup: "./e2e/global-setup.ts",
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Summary
  
  
  - `@playwright/test`, `dotenv` 추가 + `test:e2e`, `test:e2e:ui`, `test:e2e:report` scripts
  - `e2e/{fixtures, helpers, tests}` 구조 + 독립 tsconfig
  - `globalSetup`에서 storageState 기반 인증 자동화 (로그인 1회 → `.auth/user.json` 저장)
  - `mockApi` helper (`page.route` 래핑한 `fail` / `succeed` / `respond`)
  - Smoke 테스트 2개 (익명·인증 흐름 모두 통과)
  - ESLint config에 `e2e/**` react-hooks 규칙 비활성 (Playwright fixture의 `use` 콜백을 React Hook으로 오인하는
  문제 회피)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * E2E 테스트 인프라 구축 및 초기 smoke 테스트 추가
  * 인증 기능 테스트를 위한 fixture 및 전역 설정 추가

* **Chores**
  * Playwright 테스트 라이브러리 및 관련 도구 의존성 추가
  * E2E 테스트 환경 설정 파일 및 tsconfig 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FlipNoteTeam/FlipNote-FE/pull/101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->